### PR TITLE
Added a range for 200 codes for raise on fail

### DIFF
--- a/onshape.py
+++ b/onshape.py
@@ -74,7 +74,7 @@ class Onshape():
         if (raise_on_fail == None):
             raise_on_fail = self.raise_on_fail
 
-        if (raise_on_fail and resp.status_code != 200):
+        if (raise_on_fail and resp.status_code >= 200 and resp.status_code >= 206):
             result = resp.json()
             message = 'Unexpected status ' + str(resp.status_code) + ' (' + result['message'] + ')'
             raise ValueError(message, resp.status_code)


### PR DESCRIPTION
added a range on the `raise_on_fail` to exclude all 200 codes.
