### PR TITLE
Added 200 range for HTTP raise_on_fail

### DIFF
--- a/onshape.py
+++ b/onshape.py
@@ -74,7 +74,7 @@ class Onshape():
         if (raise_on_fail == None):
             raise_on_fail = self.raise_on_fail
 
-        if (raise_on_fail and resp.status_code != 200 and resp.status_code != 204):
+        if (raise_on_fail and resp.status_code >= 200 and resp.status_code <= 206):
             result = resp.json()
             message = 'Unexpected status ' + str(resp.status_code) + ' (' + result['message'] + ')'
             raise ValueError(message, resp.status_code)


### PR DESCRIPTION
added a range on the `raise_on_fail` to exclude all 200 codes.

Sorry something went wonky with my repo..all good now.
