### PR TITLE
Changes to run on Python 3

### DIFF
--- a/python/apikey/client.py
+++ b/python/apikey/client.py
@@ -5,7 +5,12 @@ client
 Convenience functions for working with the Onshape API
 '''
 
-from onshape import Onshape
+import sys
+
+if sys.version_info.major == 2:
+    from onshape import Onshape
+else:
+    from .onshape import Onshape
 
 import mimetypes
 import random

--- a/python/apikey/onshape.py
+++ b/python/apikey/onshape.py
@@ -10,13 +10,15 @@ import sys
 if sys.version_info.major == 2:
     import utils
     import urllib
-    from urlparse import urlparse, urlencode
+    from urlparse import urlparse
     from urlparse import parse_qs
+    from urllib import urlencode
 else:
     from . import utils
     import urllib.parse
-    from urllib.parse import urlparse, urlencode
+    from urllib.parse import urlparse
     from urllib.parse import parse_qs
+    from urllib.parse import urlencode
 
 import os
 import random

--- a/python/apikey/onshape.py
+++ b/python/apikey/onshape.py
@@ -5,7 +5,18 @@ onshape
 Provides access to the Onshape REST API
 '''
 
-import utils
+import sys
+
+if sys.version_info.major == 2:
+    import utils
+    import urllib
+    from urlparse import urlparse, urlencode
+    from urlparse import parse_qs
+else:
+    from . import utils
+    import urllib.parse
+    from urllib.parse import urlparse, urlencode
+    from urllib.parse import parse_qs
 
 import os
 import random
@@ -14,11 +25,8 @@ import json
 import hmac
 import hashlib
 import base64
-import urllib
 import datetime
 import requests
-from urlparse import urlparse
-from urlparse import parse_qs
 
 __all__ = [
     'Onshape'
@@ -104,13 +112,14 @@ class Onshape():
             - ctype (str, default='application/json'): HTTP Content-Type
         '''
 
-        query = urllib.urlencode(query)
+        query = urlencode(query)
 
         hmac_str = (method + '\n' + nonce + '\n' + date + '\n' + ctype + '\n' + path +
                     '\n' + query + '\n').lower().encode('utf-8')
 
         signature = base64.b64encode(hmac.new(self._secret_key, hmac_str, digestmod=hashlib.sha256).digest())
-        auth = 'On ' + self._access_key + ':HmacSHA256:' + signature.decode('utf-8')
+        #auth = 'On ' + self._access_key + ':HmacSHA256:' + signature.decode('utf-8')
+        auth = 'On ' + self._access_key.decode('utf-8') + ':HmacSHA256:' + signature.decode('utf-8')
 
         if self._logging:
             utils.log({
@@ -176,7 +185,7 @@ class Onshape():
         req_headers = self._make_headers(method, path, query, headers)
         if base_url is None:
             base_url = self._url
-        url = base_url + path + '?' + urllib.urlencode(query)
+        url = base_url + path + '?' + urlencode(query)
 
         if self._logging:
             utils.log(body)

--- a/python/app.py
+++ b/python/app.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 '''
 app
 ===
@@ -22,15 +24,15 @@ wid = new_doc['defaultWorkspace']['id']
 
 # get the document details
 details = c.get_document(did)
-print 'Document name: ' + details.json()['name']
+print('Document name: ' + details.json()['name'])
 
 # create a new assembly
 asm = c.create_assembly(did, wid)
 
 if asm.json()['name'] == 'My Assembly':
-    print 'Assembly created'
+    print('Assembly created')
 else:
-    print 'Error: Assembly not created'
+    print('Error: Assembly not created')
 
 # upload blob
 blob = c.upload_blob(did, wid)
@@ -42,6 +44,6 @@ c.del_document(did)
 trashed_doc = c.get_document(did)
 
 if trashed_doc.json()['trash'] is True:
-    print 'Document now in trash'
+    print('Document now in trash')
 else:
-    print 'Error: Document not trashed'
+    print('Error: Document not trashed')


### PR DESCRIPTION
I made some changes to make apikey compatible with both Python 2.x and Python 3.x. I have tested it on both Python 2.7 and Python 3.6.

The changes could be made cleaner with adding a dependency on the six library but that seems overkill for the handful of changes.

Len